### PR TITLE
[DCMAW-8673] Update GitHub workflows actions to use commit shas for versioning

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Run checkout github action
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           lfs: 'true'
           fetch-depth: 0

--- a/.github/workflows/on_push-main.yml
+++ b/.github/workflows/on_push-main.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: macos-latest
     #    runs-on: ubuntu-20.04-16core # Larger github runner, with KVM acceleration
     permissions:
-#      id-token: write
+      #      id-token: write
       contents: write
       packages: write
     steps:
       - name: Run checkout github action
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           lfs: 'true'
           fetch-depth: 0

--- a/.github/workflows/on_push-release.yml
+++ b/.github/workflows/on_push-release.yml
@@ -18,7 +18,7 @@ jobs:
       version: ${{ steps.version-number.outputs.version }}
     steps:
       - name: Run checkout github action
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           lfs: 'true'
           fetch-depth: 0
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Run checkout github action
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           lfs: 'true'
           fetch-depth: 0

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -17,10 +17,10 @@ jobs:
   onPushJob:
     name: Verify code base when pushed
     runs-on: macos-latest
-#    runs-on: ubuntu-20.04-16core # Larger github runner, with KVM acceleration
+    #    runs-on: ubuntu-20.04-16core # Larger github runner, with KVM acceleration
     steps:
       - name: Run checkout github action
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           lfs: 'true'
           fetch-depth: 0

--- a/.github/workflows/on_schedule.yml
+++ b/.github/workflows/on_schedule.yml
@@ -13,10 +13,10 @@ jobs:
   onScheduleJob:
     name: Verify code base when pushed
     runs-on: macos-latest
-#    runs-on: ubuntu-20.04-16core # Larger github runner, with KVM acceleration
+    #    runs-on: ubuntu-20.04-16core # Larger github runner, with KVM acceleration
     steps:
       - name: Run checkout github action
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
         with:
           lfs: 'true'
           fetch-depth: 0

--- a/config/actions/bundle-reports/action.yml
+++ b/config/actions/bundle-reports/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Upload build reports
       id: uploadBuildReports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3
       with:
         name: build-reports
         retention-days: 1

--- a/config/actions/ensure-version-is-correct/action.yml
+++ b/config/actions/ensure-version-is-correct/action.yml
@@ -19,14 +19,14 @@ runs:
   steps:
     - name: Get latest tagged version
       id: get-latest-tag
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # pin@v6
       with:
         script: |
           const current = process.env.CURRENT
           const next = process.env.NEXT
           const [cMaj, cMin, cPat] = current.split(".")
           const [nMaj, nMin, nPat] = next.split(".")
-          
+
           if (
             nMaj > cMaj ||
             (nMaj == cMaj && nMin > cMin) ||

--- a/config/actions/gradle-connected-test/action.yml
+++ b/config/actions/gradle-connected-test/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Run gradle connected test
-      uses: reactivecircus/android-emulator-runner@v2
+      uses: reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 # pin@v2
       with:
         api-level: 30
         arch: ${{ inputs.architecture }}

--- a/config/actions/retrieve-secrets/action.yml
+++ b/config/actions/retrieve-secrets/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # pin@v4.0.2
       with:
         aws-region: eu-west-2
         role-to-assume: ${{ inputs.actions-role-arn }}
@@ -18,13 +18,13 @@ runs:
         role-skip-session-tagging: true
 
     - name: Store GitHub actions ENV from AWS SecretManager
-      uses: say8425/aws-secrets-manager-actions@v2.2.1
+      uses: say8425/aws-secrets-manager-actions@d4ec1a7bf14738c1224d9842b57ea45bd1b2892f # pin@v2.2.1
       with:
         AWS_DEFAULT_REGION: "eu-west-2"
         SECRET_NAME: "di-ipv-dca-mob-android/github-actions-env-v2"
 
     - name: Store Google Play Service ENV from AWS SecretManager
-      uses: say8425/aws-secrets-manager-actions@v2.2.1
+      uses: say8425/aws-secrets-manager-actions@d4ec1a7bf14738c1224d9842b57ea45bd1b2892f # pin@v2.2.1
       with:
         AWS_DEFAULT_REGION: "eu-west-2"
         SECRET_NAME: "di-ipv-dca-mob-android/google-play-service-account-json-v2"

--- a/config/actions/setup-runner/action.yml
+++ b/config/actions/setup-runner/action.yml
@@ -16,7 +16,7 @@ runs:
       shell: bash
       run: echo "/usr/local/bin" >> $GITHUB_PATH
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # pin@v3
       with:
         distribution: 'oracle'
         java-version: ${{ inputs.jdk-version }}
@@ -54,10 +54,9 @@ runs:
       shell: bash
       if: runner.os == 'Linux'
 
-# https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
+    # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
     - name: Configure KVM hardware acceleration
-      run:
-        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+      run: echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
       shell: bash
       if: runner.os == 'Linux'
 
@@ -85,14 +84,14 @@ runs:
 
     - name: Setup Gradle
       id: setupGradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # pin@v2
       env:
         CI: 'true'
       with:
         gradle-version: ${{ inputs.gradle-version }}
 
     - name: Setup Android SDK
-      uses: android-actions/setup-android@v2
+      uses: android-actions/setup-android@7c5672355aaa8fde5f97a91aa9a99616d1ace6bc # pin@v2
 
     - name: Update Android SDK Manager
       run: |

--- a/config/actions/upload-dokka/action.yml
+++ b/config/actions/upload-dokka/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Upload Dokka Documentation
       id: uploadDokka
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3
       with:
         name: documentation
         retention-days: 14


### PR DESCRIPTION
Update GitHub workflow actions to use commit shas for versioning to improve security.
Update `configure-aws-credentials` action to version 4.0.2 for `retrieve-secrets`.
`pin-github-action` also carried out linting for the workflows.


[DCMAW-8673](https://govukverify.atlassian.net/jira/software/c/projects/DCMAW/boards/440?quickFilter=1326&selectedIssue=DCMAW-8673)

[DCMAW-8673]: https://govukverify.atlassian.net/browse/DCMAW-8673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ