### PR TITLE
ci: adding sonar gate

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -71,5 +71,15 @@ jobs:
           project-version: ${{ steps.version-name.outputs.version-name }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
 
+
+      # Check the Quality Gate status.
+      - name: SonarQube Quality Gate check
+        id: sonarqube-quality-gate-check
+        uses: sonarsource/sonarqube-quality-gate-action@d304d050d930b02a896b0f85935344f023928496 # pin@v1.1.0
+        # Force to fail step after specific time.
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
       - name: Bundle reports folder
         uses: ./config/actions/bundle-reports


### PR DESCRIPTION
Added blocking SonarCloud gate to ensure coverage level is met for new changes.

**Superseded by #36** 