### PR TITLE
fix: Add fixes for integration into OL 

### DIFF
--- a/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
@@ -1,6 +1,5 @@
 package uk.gov.android.authentication.integrity
 
-import android.util.Log
 import uk.gov.android.authentication.integrity.appcheck.AppChecker
 import uk.gov.android.authentication.integrity.model.AppCheckToken
 import uk.gov.android.authentication.integrity.model.AppIntegrityConfiguration

--- a/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
@@ -1,5 +1,6 @@
 package uk.gov.android.authentication.integrity
 
+import android.util.Log
 import uk.gov.android.authentication.integrity.appcheck.AppChecker
 import uk.gov.android.authentication.integrity.model.AppCheckToken
 import uk.gov.android.authentication.integrity.model.AppIntegrityConfiguration

--- a/app/src/main/java/uk/gov/android/authentication/integrity/appcheck/AppChecker.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/appcheck/AppChecker.kt
@@ -6,5 +6,5 @@ import uk.gov.android.authentication.integrity.model.AppCheckToken
 interface AppChecker {
     fun init(context: Context)
 
-    fun getAppCheckToken(): Result<AppCheckToken>
+    suspend fun getAppCheckToken(): Result<AppCheckToken>
 }

--- a/app/src/main/java/uk/gov/android/authentication/integrity/usecase/AttestationCaller.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/usecase/AttestationCaller.kt
@@ -11,6 +11,6 @@ fun interface AttestationCaller {
     data class Response(val jwt: String, val expiresIn: Long)
 
     companion object {
-        protected const val FIREBASE_HEADER = "X-Firebase-AppCheck"
+        const val FIREBASE_HEADER = "X-Firebase-AppCheck"
     }
 }


### PR DESCRIPTION
- remove protected declaration as it will not allow for it to
be used within the OL impl of AppIntegrity
- make getAppCheckToken suspend function to allow for the impl to await
for the reponse from Firebase