### PR TITLE
feat: Add functionality for mobile-backend/client-attestation call

### DIFF
--- a/app/src/androidTest/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManagerTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManagerTest.kt
@@ -33,6 +33,8 @@ class FirebaseClientAttestationManagerTest {
     fun check_success_response_from_get_attestation(): Unit = runBlocking {
         whenever(mockAppChecker.getAppCheckToken())
             .thenReturn(Result.success(AppCheckToken("Success")))
+        whenever(clientAttestationManager.getAttestation())
+            .thenReturn(AttestationResponse.Success("Success"))
         val result = clientAttestationManager.getAttestation()
 
         assertEquals(AttestationResponse.Success("Success"),
@@ -40,13 +42,25 @@ class FirebaseClientAttestationManagerTest {
     }
 
     @Test
-    fun check_failure_response_from_get_attestation() = runBlocking {
+    fun check_failure_response_from_get_firebase_token() = runBlocking {
         whenever(mockAppChecker.getAppCheckToken()).thenReturn(
             Result.failure(Exception("Error"))
         )
         val result = clientAttestationManager.getAttestation()
 
         assertEquals(Exception("Error").toString(),
+            (result as AttestationResponse.Failure).reason)
+    }
+
+    @Test
+    fun check_failure_response_from_get_attestation() = runBlocking {
+        whenever(mockAppChecker.getAppCheckToken())
+            .thenReturn(Result.success(AppCheckToken("Success")))
+        whenever(clientAttestationManager.getAttestation())
+            .thenReturn(AttestationResponse.Failure("Error"))
+        val result = clientAttestationManager.getAttestation()
+
+        assertEquals("Error",
             (result as AttestationResponse.Failure).reason)
     }
 

--- a/app/src/androidTest/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManagerTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManagerTest.kt
@@ -35,10 +35,13 @@ class FirebaseClientAttestationManagerTest {
         whenever(mockAppChecker.getAppCheckToken())
             .thenReturn(Result.success(AppCheckToken("Success")))
         whenever(caller.call(any(), any()))
-            .thenReturn(Result.success(AttestationResponse.Success("Success")))
+            .thenReturn(AttestationResponse.Success(
+                "Success",
+                "0"
+            ))
         val result = clientAttestationManager.getAttestation()
 
-        assertEquals(AttestationResponse.Success("Success"),
+        assertEquals(AttestationResponse.Success("Success", "0"),
             result)
     }
 
@@ -58,7 +61,7 @@ class FirebaseClientAttestationManagerTest {
         whenever(mockAppChecker.getAppCheckToken())
             .thenReturn(Result.success(AppCheckToken("Success")))
         whenever(caller.call(any(), any()))
-            .thenReturn(Result.success(AttestationResponse.Failure("Error")))
+            .thenReturn(AttestationResponse.Failure("Error"))
         val result = clientAttestationManager.getAttestation()
 
         assertEquals("Error",

--- a/app/src/androidTest/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManagerTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManagerTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.android.authentication.integrity
 
 import kotlinx.coroutines.runBlocking
+import org.mockito.kotlin.any
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import org.mockito.kotlin.mock
@@ -33,8 +34,8 @@ class FirebaseClientAttestationManagerTest {
     fun check_success_response_from_get_attestation(): Unit = runBlocking {
         whenever(mockAppChecker.getAppCheckToken())
             .thenReturn(Result.success(AppCheckToken("Success")))
-        whenever(clientAttestationManager.getAttestation())
-            .thenReturn(AttestationResponse.Success("Success"))
+        whenever(caller.call(any(), any()))
+            .thenReturn(Result.success(AttestationResponse.Success("Success")))
         val result = clientAttestationManager.getAttestation()
 
         assertEquals(AttestationResponse.Success("Success"),
@@ -56,8 +57,8 @@ class FirebaseClientAttestationManagerTest {
     fun check_failure_response_from_get_attestation() = runBlocking {
         whenever(mockAppChecker.getAppCheckToken())
             .thenReturn(Result.success(AppCheckToken("Success")))
-        whenever(clientAttestationManager.getAttestation())
-            .thenReturn(AttestationResponse.Failure("Error"))
+        whenever(caller.call(any(), any()))
+            .thenReturn(Result.success(AttestationResponse.Failure("Error")))
         val result = clientAttestationManager.getAttestation()
 
         assertEquals("Error",

--- a/app/src/androidTest/java/uk/gov/android/authentication/integrity/KeystoreManagerTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/authentication/integrity/KeystoreManagerTest.kt
@@ -1,12 +1,15 @@
 package uk.gov.android.authentication.integrity
 
 import android.security.keystore.KeyProperties
-import kotlin.test.BeforeTest
 import java.security.KeyStore
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalEncodingApi::class)
 class KeystoreManagerTest {
     private lateinit var keyStore: KeyStore
     private lateinit var keystoreManager: KeystoreManager
@@ -34,5 +37,28 @@ class KeystoreManagerTest {
     fun appCheckPrivateKey() {
         val privateKey = keystoreManager.appCheckPrivateKey
         assertEquals(KeyProperties.KEY_ALGORITHM_EC, privateKey.algorithm)
+    }
+
+    @Test
+    fun appCheckPublicKey() {
+        val publicKey = keystoreManager.appCheckPublicKey
+        assertEquals(KeyProperties.KEY_ALGORITHM_EC, publicKey.algorithm)
+    }
+
+    @Test
+    fun check_getPubKeyBase64ECCoord() {
+        val actual = keystoreManager.getPubKeyBase64ECCoord()
+
+        assertTrue(checkInputIsBase64(actual.first))
+        assertTrue(checkInputIsBase64(actual.second))
+    }
+
+    private fun checkInputIsBase64(input: String): Boolean {
+        return try {
+            Base64.decode(input)
+            true
+        } catch (e: IllegalArgumentException) {
+            false
+        }
     }
 }

--- a/app/src/androidTest/java/uk/gov/android/authentication/integrity/KeystoreManagerTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/authentication/integrity/KeystoreManagerTest.kt
@@ -53,6 +53,7 @@ class KeystoreManagerTest {
         assertTrue(checkInputIsBase64(actual.second))
     }
 
+    @Suppress("SwallowedException")
     private fun checkInputIsBase64(input: String): Boolean {
         return try {
             Base64.decode(input)

--- a/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
@@ -1,6 +1,5 @@
 package uk.gov.android.authentication.integrity
 
-import android.util.Log
 import uk.gov.android.authentication.integrity.appcheck.AppChecker
 import uk.gov.android.authentication.integrity.model.AppCheckToken
 import uk.gov.android.authentication.integrity.model.AppIntegrityConfiguration

--- a/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
@@ -1,12 +1,16 @@
 package uk.gov.android.authentication.integrity
 
+import android.util.Log
 import uk.gov.android.authentication.integrity.appcheck.AppChecker
 import uk.gov.android.authentication.integrity.model.AppCheckToken
 import uk.gov.android.authentication.integrity.model.AppIntegrityConfiguration
 import uk.gov.android.authentication.integrity.model.AttestationResponse
 import uk.gov.android.authentication.integrity.model.SignedResponse
 import uk.gov.android.authentication.integrity.usecase.AttestationCaller
+import uk.gov.android.authentication.integrity.usecase.JWK
+import kotlin.io.encoding.ExperimentalEncodingApi
 
+@OptIn(ExperimentalEncodingApi::class)
 @Suppress("UnusedPrivateProperty")
 class FirebaseClientAttestationManager(
     config: AppIntegrityConfiguration
@@ -21,8 +25,15 @@ class FirebaseClientAttestationManager(
             AttestationResponse.Failure(err.toString())
         }
         // If successful -> functionality to get signed attestation form Mobile back-end
+        val pubKeyECCoord = keyManager.getPubKeyBase64ECCoord()
+        val jwk = JWK.makeJWK(x = pubKeyECCoord.first, y = pubKeyECCoord.second)
         return if (token is AppCheckToken) {
-            AttestationResponse.Success(token.jwtToken)
+            attestationCaller.call(
+                token.jwtToken,
+                jwk
+            ).getOrElse { err ->
+                AttestationResponse.Failure(err.toString())
+            }
             // If unsuccessful -> return the failure
         } else {
             token as AttestationResponse.Failure

--- a/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
@@ -30,9 +30,7 @@ class FirebaseClientAttestationManager(
             attestationCaller.call(
                 token.jwtToken,
                 jwk
-            ).getOrElse { err ->
-                AttestationResponse.Failure(err.toString())
-            }
+            )
             // If unsuccessful -> return the failure
         } else {
             token as AttestationResponse.Failure

--- a/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/FirebaseClientAttestationManager.kt
@@ -10,7 +10,6 @@ import uk.gov.android.authentication.integrity.usecase.JWK
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 @OptIn(ExperimentalEncodingApi::class)
-@Suppress("UnusedPrivateProperty")
 class FirebaseClientAttestationManager(
     config: AppIntegrityConfiguration
 ) : ClientAttestationManager {

--- a/app/src/main/java/uk/gov/android/authentication/integrity/KeystoreManager.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/KeystoreManager.kt
@@ -6,7 +6,11 @@ import android.util.Log
 import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.PrivateKey
+import java.security.interfaces.ECPublicKey
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
+@ExperimentalEncodingApi
 @Suppress("MemberVisibilityCanBePrivate", "unused")
 internal class KeystoreManager {
     private val ks: KeyStore = KeyStore.getInstance(KEYSTORE).apply {
@@ -27,11 +31,22 @@ internal class KeystoreManager {
     val appCheckPrivateKey: PrivateKey
         get() = ks.getKey(ALIAS, null) as PrivateKey
 
+    val appCheckPublicKey: ECPublicKey
+        get() = ks.getCertificate(ALIAS).publicKey as ECPublicKey
+
     init {
         if (!hasAppCheckKeys) {
             Log.d(this::class.simpleName, "Generating key pair")
             createNewKeys()
         }
+    }
+
+    fun getPubKeyBase64ECCoord(): Pair<String, String> {
+        val xByteArr = appCheckPublicKey.w.affineX.toByteArray()
+        val yByteArr = appCheckPublicKey.w.affineY.toByteArray()
+        val x = Base64.encode(xByteArr)
+        val y = Base64.encode(yByteArr)
+        return Pair(x, y)
     }
 
     private fun createNewKeys() {

--- a/app/src/main/java/uk/gov/android/authentication/integrity/model/AttestationResponse.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/model/AttestationResponse.kt
@@ -1,6 +1,17 @@
 package uk.gov.android.authentication.integrity.model
 
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
+
+@OptIn(ExperimentalSerializationApi::class)
 sealed class AttestationResponse {
-    data class Success(val attestationJwt: String) : AttestationResponse()
+    @Serializable
+    data class Success(
+        @JsonNames("client_attestation")
+        val attestationJwt: String,
+        @JsonNames("expires_in")
+        val expiresIn: String
+    ) : AttestationResponse()
     data class Failure(val reason: String, val error: Throwable? = null) : AttestationResponse()
 }

--- a/app/src/main/java/uk/gov/android/authentication/integrity/usecase/AttestationCaller.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/usecase/AttestationCaller.kt
@@ -1,16 +1,17 @@
 package uk.gov.android.authentication.integrity.usecase
 
+import uk.gov.android.authentication.integrity.model.AttestationResponse
+
 @Suppress("unused")
 fun interface AttestationCaller {
     suspend fun call(
-        signedProofOfPossession: String,
-        jwkX: String,
-        jwkY: String
-    ): Result<Response>
-
-    data class Response(val jwt: String, val expiresIn: Long)
+        firebaseToken: String,
+        jwk: JWK.JsonWebKey
+    ): Result<AttestationResponse>
 
     companion object {
         const val FIREBASE_HEADER = "X-Firebase-AppCheck"
+        const val CONTENT_TYPE = "Content-type"
+        const val CONTENT_TYPE_VALUE = "application/json"
     }
 }

--- a/app/src/main/java/uk/gov/android/authentication/integrity/usecase/AttestationCaller.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/usecase/AttestationCaller.kt
@@ -7,7 +7,7 @@ fun interface AttestationCaller {
     suspend fun call(
         firebaseToken: String,
         jwk: JWK.JsonWebKey
-    ): Result<AttestationResponse>
+    ): AttestationResponse
 
     companion object {
         const val FIREBASE_HEADER = "X-Firebase-AppCheck"

--- a/app/src/main/java/uk/gov/android/authentication/integrity/usecase/JWK.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/usecase/JWK.kt
@@ -1,25 +1,34 @@
 package uk.gov.android.authentication.integrity.usecase
 
-import org.jose4j.jwk.JsonWebKey
+import kotlinx.serialization.Serializable
 
 @Suppress("MemberVisibilityCanBePrivate")
 object JWK {
-    const val keyType = "kty"
-    const val use = "use"
-    const val curve = "crv"
-    const val x = "x"
-    const val y = "y"
     private const val keyTypeValue = "EC"
     private const val useValue = "sig"
     private const val curveValue = "P-256"
 
-    fun makeJWK(x: String, y: String): JsonWebKey = JsonWebKey.Factory.newJwk(
-        mapOf(
-            keyType to keyTypeValue,
-            use to useValue,
-            curve to curveValue,
-            JWK.x to x,
-            JWK.y to y
+    fun makeJWK(x: String, y: String): JsonWebKey = JsonWebKey(
+        jwk = JsonWebKeyFormat(
+            keyTypeValue,
+            useValue,
+            curveValue,
+            x,
+            y
         )
+    )
+
+    @Serializable
+    data class JsonWebKey(
+        val jwk: JsonWebKeyFormat
+    )
+
+    @Serializable
+    data class JsonWebKeyFormat(
+        val kty: String,
+        val use: String,
+        val crv: String,
+        val x: String,
+        val y: String
     )
 }

--- a/app/src/test/java/uk/gov/android/authentication/integrity/usecase/JWKTest.kt
+++ b/app/src/test/java/uk/gov/android/authentication/integrity/usecase/JWKTest.kt
@@ -7,12 +7,20 @@ class JWKTest {
     @Test
     fun `makeJWK sets defaults`() {
         val actual = JWK.makeJWK(X, Y)
-        assertEquals(expected = "EC", actual = actual.keyType)
-        assertEquals(expected = "sig", actual = actual.use)
+        assertEquals(jwk, actual)
     }
 
     companion object {
         const val X = "18wHLeIgW9wVN6VD1Txgpqy2LszYkMf6J8njVAibvhM"
         const val Y = "-V4dS4UaLMgP_4fY4j8ir7cl1TXlFdAgcx55o7TkcSA"
+        val jwk = JWK.JsonWebKey(
+            jwk = JWK.JsonWebKeyFormat(
+                "EC",
+                "sig",
+                "P-256",
+                X,
+                Y
+            )
+        )
     }
 }


### PR DESCRIPTION
- update AttestationCaller interface to enable use of firebase token and jwk
- update jwk to a custom impl (JWK provided by jose4.jwt was not serializable) to enable use in the backend call
- update FirebaseClientAttestationManager to add logic for the attestation call once firebase call is successful
- update keystore manager to enable getting the public key in the required format

Resolves: DCMAW-10313