### PR TITLE
feat: Add the AppIntegrity Pop and ClientAttestation as header params for authentication

### DIFF
--- a/app/src/androidTest/java/uk/gov/android/authentication/login/AppAuthPresentTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/authentication/login/AppAuthPresentTest.kt
@@ -20,11 +20,13 @@ class AppAuthPresentTest {
 
     private lateinit var loginSession: LoginSession
     private lateinit var loginSessionConfig: LoginSessionConfiguration
+    private lateinit var clientAuthenticationProvider: ClientAuthenticationProvider
 
     @BeforeTest
     fun setUp() {
         val context = InstrumentationRegistry.getInstrumentation().context
-        loginSession = AppAuthSession(context)
+        clientAuthenticationProvider = ClientAuthenticationProviderImpl()
+        loginSession = AppAuthSession(context, clientAuthenticationProvider)
         loginSessionConfig = LoginSessionConfigurationTest.defaultConfig.copy()
         Intents.init()
     }

--- a/app/src/androidTest/java/uk/gov/android/authentication/login/AppAuthSessionTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/authentication/login/AppAuthSessionTest.kt
@@ -49,7 +49,7 @@ class AppAuthSessionTest {
             putExtra(AuthorizationResponse.EXTRA_RESPONSE, "{}")
         }
         // When calling finalise
-        appAuthSession.finalise(intent) {}
+        appAuthSession.finalise(intent, Pair(ATTESTATION, POP)) {}
         // Then throw an IllegalArgumentException
     }
 
@@ -59,10 +59,15 @@ class AppAuthSessionTest {
         val intent = Intent()
         // When calling finalise
         val error = assertThrows(AuthenticationError::class.java) {
-            appAuthSession.finalise(intent) {}
+            appAuthSession.finalise(intent, Pair(ATTESTATION, POP)) {}
         }
         // Then throw an AuthenticationError
         assertEquals(AuthenticationError.ErrorType.OAUTH, error.type)
         assertEquals(AuthenticationError.Companion.NULL_AUTH_MESSAGE, error.message)
+    }
+
+    companion object {
+        private const val ATTESTATION = "attestation"
+        private const val POP = "proof of possession"
     }
 }

--- a/app/src/main/java/uk/gov/android/authentication/integrity/appcheck/usecase/AppChecker.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/appcheck/usecase/AppChecker.kt
@@ -2,6 +2,19 @@ package uk.gov.android.authentication.integrity.appcheck.usecase
 
 import uk.gov.android.authentication.integrity.appcheck.model.AppCheckToken
 
+/**
+ * Interface to perform a network request that provides an [AppCheckToken] from a provider
+ * (e.g. FirebaseAppCheckFactory, custom backend AppCheck provider, etc).
+ *
+ * It is used in the process of providing a ClientAttestation for the AppIntegrityCheck - allows
+ * the integrity package to be encapsulated and not have any dependencies on network packages.
+ */
 fun interface AppChecker {
+    /**
+     * Retrieves a token that will be used in verifying the authenticity of the app.
+     *
+     * @return An [AppCheckToken] when successful, containing a JWT
+     *         or a [Result] containing the failure, otherwise.
+     */
     suspend fun getAppCheckToken(): Result<AppCheckToken>
 }

--- a/app/src/main/java/uk/gov/android/authentication/integrity/appcheck/usecase/AttestationCaller.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/appcheck/usecase/AttestationCaller.kt
@@ -2,10 +2,26 @@ package uk.gov.android.authentication.integrity.appcheck.usecase
 
 import uk.gov.android.authentication.integrity.appcheck.model.AttestationResponse
 
-@Suppress("unused")
+/**
+ * Interface to perform a network request that provides an Attestation from a custom or standard 
+ * backend service.
+ *
+ * It is used in the process of providing a ClientAttestation for the AppIntegrityCheck - allows
+ * the integrity package to be encapsulated and not have any dependencies on any network .
+ */
 fun interface AttestationCaller {
+    /**
+     * Retrieves a ClientAttestation from the Mobile backend provided a Public Key and
+     * a AppCheckToken.
+     *
+     * @param token - The AppCheckToken retrieved from [AppChecker].
+     * @param jwk - The Json Web Key (public key) that the PoP will be signed with.
+     *
+     * @return An [AttestationResponse] object indicating success or failure.
+     *         On success, the response contains the signed attestation statement.
+     */
     suspend fun call(
-        firebaseToken: String,
+        token: String,
         jwk: JWK.JsonWebKey
     ): AttestationResponse
 

--- a/app/src/main/java/uk/gov/android/authentication/integrity/appcheck/usecase/JWK.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/appcheck/usecase/JWK.kt
@@ -2,6 +2,16 @@ package uk.gov.android.authentication.integrity.appcheck.usecase
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Object to create a JWK following the required format:
+ *
+ * @param x - Elliptic Curve Point (ECPoint) x in Base64UrlEncoded format
+ *          of the public key corresponding to the private key used to sign the PoP.
+ * @param y - ECPoint y in in Base64UrlEncoded format of the public key corresponding to the private
+ *          key used to sign the PoP.
+ *
+ * @return A custom [JsonWebKey].
+ */
 @Suppress("MemberVisibilityCanBePrivate")
 object JWK {
     private const val keyTypeValue = "EC"

--- a/app/src/main/java/uk/gov/android/authentication/login/AppAuthSession.kt
+++ b/app/src/main/java/uk/gov/android/authentication/login/AppAuthSession.kt
@@ -2,7 +2,6 @@ package uk.gov.android.authentication.login
 
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationResponse
@@ -37,6 +36,7 @@ class AppAuthSession(
             )
         }
 
+        // Create object that allows for additional headers/ body parameters
         val clientAuthenticationWithExtraHeaders = object : ClientAuthentication {
             override fun getRequestHeaders(clientId: String): MutableMap<String, String> =
                 mutableMapOf(
@@ -48,8 +48,9 @@ class AppAuthSession(
                 mutableMapOf()
         }
 
+        // Create the standard request
         val request = authResponse.createTokenExchangeRequest()
-        Log.d("TokenRequest", "${request.requestParameters}")
+
         authService.performTokenRequest(
             request,
             clientAuthenticationWithExtraHeaders

--- a/app/src/main/java/uk/gov/android/authentication/login/AppAuthSession.kt
+++ b/app/src/main/java/uk/gov/android/authentication/login/AppAuthSession.kt
@@ -2,9 +2,12 @@ package uk.gov.android.authentication.login
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
+import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
+import net.openid.appauth.ClientAuthentication
 
 class AppAuthSession(
     context: Context,
@@ -21,16 +24,44 @@ class AppAuthSession(
 
     override fun finalise(
         intent: Intent,
+        appIntegrity: Pair<String?, String?>,
         callback: (tokens: TokenResponse) -> Unit
     ) {
         val authResponse = AuthorizationResponse.fromIntent(intent)
-        val request = authResponse?.createTokenExchangeRequest() ?: throw AuthenticationError.from(intent)
+        if (authResponse == null) {
+            val exception = AuthorizationException.fromIntent(intent)
+
+            throw AuthenticationError(
+                exception?.message ?: "Auth response null",
+                AuthenticationError.ErrorType.OAUTH
+            )
+        }
+
+        val clientAuthenticationWithExtraHeaders = object : ClientAuthentication {
+            override fun getRequestHeaders(clientId: String): MutableMap<String, String> =
+                mutableMapOf(
+                    Pair(CLIENT_ATTESTATION, appIntegrity.first ?: ""),
+                    Pair(PROOF_OF_POSSESSION, appIntegrity.second ?: "")
+                )
+
+            override fun getRequestParameters(clientId: String): MutableMap<String, String> =
+                mutableMapOf()
+        }
+
+        val request = authResponse.createTokenExchangeRequest()
+        Log.d("TokenRequest", "${request.requestParameters}")
         authService.performTokenRequest(
-            request
+            request,
+            clientAuthenticationWithExtraHeaders
         ) { response, exception ->
             callback(
                 response?.toTokenResponse() ?: throw AuthenticationError.from(exception)
             )
         }
+    }
+
+    companion object {
+        private const val CLIENT_ATTESTATION = "OAuth-Client-Attestation"
+        private const val PROOF_OF_POSSESSION = "OAuth-Client-Attestation-PoP"
     }
 }

--- a/app/src/main/java/uk/gov/android/authentication/login/ClientAuthenticationProvider.kt
+++ b/app/src/main/java/uk/gov/android/authentication/login/ClientAuthenticationProvider.kt
@@ -1,0 +1,33 @@
+package uk.gov.android.authentication.login
+
+import net.openid.appauth.ClientAuthentication
+
+fun interface ClientAuthenticationProvider {
+    fun setCustomClientAuthentication(
+        clientAttestation: String?,
+        proofOfPossession: String?
+    ): ClientAuthentication
+}
+
+class ClientAuthenticationProviderImpl : ClientAuthenticationProvider {
+    override fun setCustomClientAuthentication(
+        clientAttestation: String?,
+        proofOfPossession: String?
+    ): ClientAuthentication {
+        return object : ClientAuthentication {
+            override fun getRequestHeaders(clientId: String): MutableMap<String, String> =
+                mutableMapOf(
+                    Pair(CLIENT_ATTESTATION, clientAttestation ?: ""),
+                    Pair(PROOF_OF_POSSESSION, proofOfPossession ?: "")
+                )
+
+            override fun getRequestParameters(clientId: String): MutableMap<String, String> =
+                mutableMapOf()
+        }
+    }
+
+    companion object {
+        private const val CLIENT_ATTESTATION = "OAuth-Client-Attestation"
+        private const val PROOF_OF_POSSESSION = "OAuth-Client-Attestation-PoP"
+    }
+}

--- a/app/src/main/java/uk/gov/android/authentication/login/LoginSession.kt
+++ b/app/src/main/java/uk/gov/android/authentication/login/LoginSession.kt
@@ -30,6 +30,7 @@ interface LoginSession {
     @Throws(Exception::class)
     fun finalise(
         intent: Intent,
+        appIntegrity: Pair<String?, String?>,
         callback: (tokens: TokenResponse) -> Unit
     )
 }

--- a/app/src/test/java/uk/gov/android/authentication/login/ClientAuthenticationProviderTest.kt
+++ b/app/src/test/java/uk/gov/android/authentication/login/ClientAuthenticationProviderTest.kt
@@ -1,0 +1,29 @@
+package uk.gov.android.authentication.login
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ClientAuthenticationProviderTest {
+    private val sut = ClientAuthenticationProviderImpl()
+
+    @Test
+    fun `provide additional header parameters`() {
+        // WHEN
+        val result = sut.setCustomClientAuthentication(
+            ATTESTATION,
+            POP
+        )
+
+        // THEN
+        assertEquals(expected, result.getRequestHeaders(""))
+    }
+
+    companion object {
+        private const val ATTESTATION = "client attestation"
+        private const val POP = "proof of possession"
+        private val expected = mutableMapOf(
+            Pair("OAuth-Client-Attestation", ATTESTATION),
+            Pair("OAuth-Client-Attestation-PoP", POP)
+        )
+    }
+}


### PR DESCRIPTION
- add ClientAttestation and PoP to finalise() method when log-in is performed to get the auth_code
- add Kedocs for AppChecker, AttestationCaller and JWK