### PR TITLE
fix!: Update TokenResponse to require idToken

### DIFF
--- a/app/src/main/java/uk/gov/android/authentication/login/TokenResponse.kt
+++ b/app/src/main/java/uk/gov/android/authentication/login/TokenResponse.kt
@@ -7,6 +7,6 @@ data class TokenResponse(
     val tokenType: String,
     val accessToken: String,
     val accessTokenExpirationTime: Long,
-    val idToken: String? = null,
+    val idToken: String,
     val refreshToken: String? = null
 )

--- a/app/src/main/java/uk/gov/android/authentication/login/TokenResponseUtil.kt
+++ b/app/src/main/java/uk/gov/android/authentication/login/TokenResponseUtil.kt
@@ -4,6 +4,7 @@ typealias AppAuthTokenResponse = net.openid.appauth.TokenResponse
 
 private const val NullTokenTypeMessage = "Token type must not be empty"
 private const val NullAccessTokenMessage = "Access token must not be empty"
+private const val NullIdTokenMessage = "ID token must not be empty"
 private const val NullTokenExpiryMessage = "Token expiry must not be empty"
 
 internal fun AppAuthTokenResponse.toTokenResponse(): TokenResponse = TokenResponse(
@@ -12,6 +13,6 @@ internal fun AppAuthTokenResponse.toTokenResponse(): TokenResponse = TokenRespon
     accessTokenExpirationTime = requireNotNull(accessTokenExpirationTime) {
         NullTokenExpiryMessage
     },
-    idToken = idToken,
+    idToken = requireNotNull(idToken) { NullIdTokenMessage },
     refreshToken = refreshToken
 )

--- a/app/src/test/java/uk/gov/android/authentication/login/TokenResponseTest.kt
+++ b/app/src/test/java/uk/gov/android/authentication/login/TokenResponseTest.kt
@@ -28,10 +28,11 @@ class TokenResponseTest {
         val tokenResponse = TokenResponse(
             "bearer",
             "sampleAccessToken",
-            3600
+            3600,
+            "sampleIdToken"
         )
         val expectedJson = "{\"tokenType\":\"bearer\",\"accessToken\":\"sampleAccessToken\"," +
-            "\"accessTokenExpirationTime\":3600}"
+            "\"accessTokenExpirationTime\":3600,\"idToken\":\"sampleIdToken\"}"
         assertEquals(expectedJson, jsonSerialize(tokenResponse))
     }
 
@@ -53,11 +54,12 @@ class TokenResponseTest {
     @Test
     fun `de-serialise TokenResponse from JSON with defaults`() {
         val json = "{\"tokenType\":\"bearer\",\"accessToken\":\"sampleAccessToken\"," +
-            "\"accessTokenExpirationTime\":3600}"
+            "\"accessTokenExpirationTime\":3600,\"idToken\":\"sampleIdToken\"}"
         val expectedTokenResponse = TokenResponse(
             "bearer",
             "sampleAccessToken",
-            3600
+            3600,
+            "sampleIdToken"
         )
         assertEquals(expectedTokenResponse, jsonDeserialize(json))
     }


### PR DESCRIPTION
- update TokenResponse to require an idToken to be set

BREAKING CHANGES: TokenReponse now requires an IdToken to nonNull