### PR TITLE
build: bump android-gradle from 8.7.3 to 8.8.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 core-ktx = "1.13.1"
 junit = "5.11.4"
 appcompat = "1.7.0"
-androidGradlePlugin = "8.7.3"
+androidGradlePlugin = "8.8.0"
 kotlin = "2.1.0"
 serialization = "1.8.0"
 detekt-gradle = "1.23.7" # https://github.com/detekt/detekt/releases/tag/v1.23.6

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bumps `android-gradle` from 8.7.3 to 8.8.0.
Updates `com.android.tools.build:gradle` from 8.7.3 to 8.8.0
Updates `com.android.application` from 8.7.3 to 8.8.0
Updates `com.android.library` from 8.7.3 to 8.8.0