### PR TITLE
feat: Add functionality for re-auth `access_denied`

### DIFF
--- a/app/src/androidTest/java/uk/gov/android/authentication/login/AppAuthSessionTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/authentication/login/AppAuthSessionTest.kt
@@ -6,6 +6,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import net.openid.appauth.AuthorizationException
+import net.openid.appauth.AuthorizationException.AuthorizationRequestErrors
 import net.openid.appauth.AuthorizationResponse
 import org.junit.Assert.assertThrows
 import org.mockito.kotlin.any
@@ -75,6 +77,29 @@ class AppAuthSessionTest {
         // When calling finalise
         appAuthSession.finalise(intent, AppIntegrityParameters(ATTESTATION, POP)) {}
         // Then throw an IllegalArgumentException
+    }
+
+    @Test
+    fun finaliseThrowsAuthenticationErrorOfAccessDenied() {
+        val exception = AuthorizationException(
+            AuthorizationException.TYPE_OAUTH_AUTHORIZATION_ERROR,
+            AuthorizationRequestErrors.ACCESS_DENIED.code,
+            AuthorizationRequestErrors.ACCESS_DENIED.error,
+            AuthorizationRequestErrors.ACCESS_DENIED.errorDescription,
+            AuthorizationRequestErrors.ACCESS_DENIED.errorUri,
+            AuthorizationRequestErrors.ACCESS_DENIED.cause
+        )
+        // Given an intent with a malformed (empty) response data JSON extra
+        val intent = Intent().putExtra(
+            AuthorizationException.EXTRA_EXCEPTION,
+            exception.toJsonString()
+        )
+        // When calling finalise
+        val result = assertThrows(AuthenticationError::class.java) {
+            appAuthSession.finalise(intent, AppIntegrityParameters(ATTESTATION, POP)) {}
+        }
+        // Then throw an IllegalArgumentException
+        assertEquals(AuthenticationError.ErrorType.ACCESS_DENIED, result.type)
     }
 
     @Test

--- a/app/src/main/java/uk/gov/android/authentication/login/AuthenticationError.kt
+++ b/app/src/main/java/uk/gov/android/authentication/login/AuthenticationError.kt
@@ -21,7 +21,7 @@ class AuthenticationError(
         fun from(exception: AuthorizationException?): AuthenticationError {
             return when (exception) {
                 AuthorizationRequestErrors.ACCESS_DENIED -> AuthenticationError(
-                    message = exception?.message ?: NULL_AUTH_MESSAGE,
+                    message = exception.message ?: NULL_AUTH_MESSAGE,
                     type = ErrorType.ACCESS_DENIED
                 )
 

--- a/app/src/main/java/uk/gov/android/authentication/login/AuthenticationError.kt
+++ b/app/src/main/java/uk/gov/android/authentication/login/AuthenticationError.kt
@@ -2,6 +2,7 @@ package uk.gov.android.authentication.login
 
 import android.content.Intent
 import net.openid.appauth.AuthorizationException
+import net.openid.appauth.AuthorizationException.AuthorizationRequestErrors
 
 class AuthenticationError(
     override val message: String,
@@ -9,7 +10,7 @@ class AuthenticationError(
 ) : Error() {
     enum class ErrorType {
         OAUTH,
-        NETWORK
+        ACCESS_DENIED
     }
 
     companion object {
@@ -17,9 +18,18 @@ class AuthenticationError(
 
         fun from(intent: Intent) = from(AuthorizationException.fromIntent(intent))
 
-        fun from(exception: AuthorizationException?) = AuthenticationError(
-            message = exception?.message ?: NULL_AUTH_MESSAGE,
-            type = ErrorType.OAUTH
-        )
+        fun from(exception: AuthorizationException?): AuthenticationError {
+            return when (exception) {
+                AuthorizationRequestErrors.ACCESS_DENIED -> AuthenticationError(
+                    message = exception?.message ?: NULL_AUTH_MESSAGE,
+                    type = ErrorType.ACCESS_DENIED
+                )
+
+                else -> AuthenticationError(
+                    message = exception?.message ?: NULL_AUTH_MESSAGE,
+                    type = ErrorType.OAUTH
+                )
+            }
+        }
     }
 }

--- a/app/src/test/java/uk/gov/android/authentication/login/AuthenticationErrorTest.kt
+++ b/app/src/test/java/uk/gov/android/authentication/login/AuthenticationErrorTest.kt
@@ -5,13 +5,15 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import net.openid.appauth.AuthorizationException
+import net.openid.appauth.AuthorizationException.AuthorizationRequestErrors
+import uk.gov.android.authentication.login.AuthenticationError.ErrorType
 
 class AuthenticationErrorTest {
     @Test
     fun `Error construction with message and type`() {
         // When constructing AuthenticationError
         val errorMessage = "Invalid credentials"
-        val error = AuthenticationError(errorMessage, AuthenticationError.ErrorType.OAUTH)
+        val error = AuthenticationError(errorMessage, ErrorType.OAUTH)
         // Then set the message and type member variables
         assertEquals(errorMessage, error.message)
         assertEquals(AuthenticationError.ErrorType.OAUTH, error.type)
@@ -27,6 +29,23 @@ class AuthenticationErrorTest {
         val actual = AuthenticationError.Companion.from(intent)
         // Then return an AuthenticationError
         assertIs<AuthenticationError>(actual)
+    }
+
+    @Test
+    fun `from(exception Exception) creates AuthenticationError of type access_denied`() {
+        // Given an Intent that doesn't map to AuthorizationException
+        val exception = AuthorizationException(
+            AuthorizationException.TYPE_OAUTH_AUTHORIZATION_ERROR,
+            AuthorizationRequestErrors.ACCESS_DENIED.code,
+            AuthorizationRequestErrors.ACCESS_DENIED.error,
+            AuthorizationRequestErrors.ACCESS_DENIED.errorDescription,
+            AuthorizationRequestErrors.ACCESS_DENIED.errorUri,
+            AuthorizationRequestErrors.ACCESS_DENIED.cause
+        )
+        // When calling the from mapping method
+        val actual = AuthenticationError.Companion.from(exception)
+        // Then return an AuthenticationError
+        assertEquals(ErrorType.ACCESS_DENIED, actual.type)
     }
 
     @Test


### PR DESCRIPTION
- add mapping for `AuthorizationRequestErrors.ACCESS_DENIED`

Resolves: DCMAW-11376