### PR TITLE
fix: Add functionality to enforce local auth required on Skip

### DIFF
--- a/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManagerImpl.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManagerImpl.kt
@@ -118,7 +118,7 @@ open class LocalAuthManagerImpl(
                         localAuthPrefRepo.setLocalAuthPref(
                             LocalAuthPreference.Disabled,
                         )
-                        callbackHandler.onSuccess(true)
+                        setLocalAuthBehaviour(isLocalAuthRequired, callbackHandler, true)
                     },
                     onBiometricsOptIn = {
                         localAuthPrefRepo.setLocalAuthPref(
@@ -130,11 +130,7 @@ open class LocalAuthManagerImpl(
                         localAuthPrefRepo.setLocalAuthPref(
                             LocalAuthPreference.Disabled,
                         )
-                        if (isLocalAuthRequired) {
-                            callbackHandler.onFailure(false)
-                        } else {
-                            callbackHandler.onSuccess(false)
-                        }
+                        setLocalAuthBehaviour(isLocalAuthRequired, callbackHandler)
                     },
                 )
             }
@@ -146,6 +142,18 @@ open class LocalAuthManagerImpl(
                     .setLocalAuthPref(LocalAuthPreference.Enabled(false))
                 callbackHandler.onSuccess(false)
             }
+        }
+    }
+
+    private fun setLocalAuthBehaviour(
+        isLocalAuthRequired: Boolean,
+        callbackHandler: LocalAuthManagerCallbackHandler,
+        backButtonPressed: Boolean = false,
+    ) {
+        if (isLocalAuthRequired) {
+            callbackHandler.onFailure(backButtonPressed)
+        } else {
+            callbackHandler.onSuccess(backButtonPressed)
         }
     }
 }

--- a/localauth/src/test/java/uk/gov/android/localauth/LocalAuthManagerTest.kt
+++ b/localauth/src/test/java/uk/gov/android/localauth/LocalAuthManagerTest.kt
@@ -177,7 +177,7 @@ class LocalAuthManagerTest : FragmentActivityTestCase(true) {
                 Espresso.pressBack()
             }
 
-            verify(callbackHandler).onSuccess(true)
+            verify(callbackHandler).onFailure(true)
             verify(localAuthPreferenceRepository).getLocalAuthPref()
             verify(localAuthPreferenceRepository)
                 .setLocalAuthPref(LocalAuthPreference.Disabled)


### PR DESCRIPTION
- when  local auth is required and the BioOpInScreen is showed and the user skips, then it will call onFailure, rather than onSuccess