### PR TITLE
feat!: Add biometrics opt out screen and analytics

### DIFF
--- a/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManager.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManager.kt
@@ -20,13 +20,15 @@ interface LocalAuthManager {
      * local auth preference.
      *
      * @param walletEnabled if the consumer has access to Wallet, it is used to display the correct [BioOptInScreen] copy
-     * @param localAuhRequired enforces local authentication on the device - when this is set to true, it requires the device to be secure.
+     * @param localAuthRequired enforces local authentication on the device - when this is set to true, it requires the device to be secure.
+     * @param walletAddCredentialAttempt indicates whether an attempt to add a Wallet credential is made
      * @param activity is required to allow the [BiometricsUiManager] to display dialogs on top of the consumer underlying activity
      * @param callbackHandler allows the consumer to provide implementation for success or failure results/ outcomes
      */
     suspend fun enforceAndSet(
         walletEnabled: Boolean,
-        localAuhRequired: Boolean,
+        localAuthRequired: Boolean,
+        walletAddCredentialAttempt: Boolean = false,
         activity: FragmentActivity,
         callbackHandler: LocalAuthManagerCallbackHandler,
     )

--- a/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManager.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManager.kt
@@ -21,14 +21,14 @@ interface LocalAuthManager {
      *
      * @param walletEnabled if the consumer has access to Wallet, it is used to display the correct [BioOptInScreen] copy
      * @param localAuthRequired enforces local authentication on the device - when this is set to true, it requires the device to be secure.
-     * @param walletAddCredentialAttempt indicates whether an attempt to add a Wallet credential is made
+     * @param enableOptOut indicates whether the opt out screen should be displayed when user skips biometrics opt in
      * @param activity is required to allow the [BiometricsUiManager] to display dialogs on top of the consumer underlying activity
      * @param callbackHandler allows the consumer to provide implementation for success or failure results/ outcomes
      */
     suspend fun enforceAndSet(
         walletEnabled: Boolean,
         localAuthRequired: Boolean,
-        walletAddCredentialAttempt: Boolean = false,
+        enableOptOut: Boolean = false,
         activity: FragmentActivity,
         callbackHandler: LocalAuthManagerCallbackHandler,
     )

--- a/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManager.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManager.kt
@@ -21,14 +21,12 @@ interface LocalAuthManager {
      *
      * @param walletEnabled if the consumer has access to Wallet, it is used to display the correct [BioOptInScreen] copy
      * @param localAuthRequired enforces local authentication on the device - when this is set to true, it requires the device to be secure.
-     * @param enableOptOut indicates whether the opt out screen should be displayed when user skips biometrics opt in
      * @param activity is required to allow the [BiometricsUiManager] to display dialogs on top of the consumer underlying activity
      * @param callbackHandler allows the consumer to provide implementation for success or failure results/ outcomes
      */
     suspend fun enforceAndSet(
         walletEnabled: Boolean,
         localAuthRequired: Boolean,
-        enableOptOut: Boolean = false,
         activity: FragmentActivity,
         callbackHandler: LocalAuthManagerCallbackHandler,
     )

--- a/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManagerImpl.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManagerImpl.kt
@@ -40,7 +40,7 @@ open class LocalAuthManagerImpl(
     override suspend fun enforceAndSet(
         walletEnabled: Boolean,
         localAuthRequired: Boolean,
-        walletAddCredentialAttempt: Boolean,
+        enableOptOut: Boolean,
         activity: FragmentActivity,
         callbackHandler: LocalAuthManagerCallbackHandler,
     ) {
@@ -58,7 +58,7 @@ open class LocalAuthManagerImpl(
                         activity,
                         walletEnabled,
                         localAuthRequired,
-                        walletAddCredentialAttempt,
+                        enableOptOut,
                     )
                 }
             }

--- a/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManagerImpl.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/LocalAuthManagerImpl.kt
@@ -40,7 +40,6 @@ open class LocalAuthManagerImpl(
     override suspend fun enforceAndSet(
         walletEnabled: Boolean,
         localAuthRequired: Boolean,
-        enableOptOut: Boolean,
         activity: FragmentActivity,
         callbackHandler: LocalAuthManagerCallbackHandler,
     ) {
@@ -58,7 +57,6 @@ open class LocalAuthManagerImpl(
                         activity,
                         walletEnabled,
                         localAuthRequired,
-                        enableOptOut,
                     )
                 }
             }
@@ -116,7 +114,6 @@ open class LocalAuthManagerImpl(
         activity: FragmentActivity,
         walletEnabled: Boolean,
         isLocalAuthRequired: Boolean,
-        walletAddCredentialAttempt: Boolean,
     ) {
         when (deviceBiometricsManager.getCredentialStatus()) {
             DeviceBiometricsStatus.SUCCESS -> {
@@ -143,7 +140,6 @@ open class LocalAuthManagerImpl(
                             activity,
                             isLocalAuthRequired,
                             callbackHandler,
-                            walletAddCredentialAttempt,
                         )
                     },
                 )
@@ -174,25 +170,20 @@ open class LocalAuthManagerImpl(
         activity: FragmentActivity,
         isLocalAuthRequired: Boolean,
         callbackHandler: LocalAuthManagerCallbackHandler,
-        walletAddCredentialAttempt: Boolean,
     ) {
         if (isLocalAuthRequired) {
-            if (walletAddCredentialAttempt) {
-                uiManager.displayBioOptOut(
-                    activity,
-                    onBack = {
-                        callbackHandler.onFailure(backButtonPressed = true)
-                    },
-                    onBiometricsOptIn = {
-                        localAuthPrefRepo.setLocalAuthPref(
-                            LocalAuthPreference.Enabled(true),
-                        )
-                        callbackHandler.onSuccess(false)
-                    },
-                )
-            } else {
-                callbackHandler.onFailure(backButtonPressed = false)
-            }
+            uiManager.displayBioOptOut(
+                activity,
+                onBack = {
+                    callbackHandler.onFailure(backButtonPressed = true)
+                },
+                onBiometricsOptIn = {
+                    localAuthPrefRepo.setLocalAuthPref(
+                        LocalAuthPreference.Enabled(true),
+                    )
+                    callbackHandler.onSuccess(false)
+                },
+            )
         } else {
             callbackHandler.onSuccess(backButtonPressed = false)
         }

--- a/localauth/src/main/java/uk/gov/android/localauth/ui/BiometricsUiManager.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/ui/BiometricsUiManager.kt
@@ -4,6 +4,7 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.FragmentActivity
 import uk.gov.android.localauth.ui.optin.BioOptInScreen
+import uk.gov.android.localauth.ui.optout.BioOptOutScreen
 import uk.gov.android.localauth.ui.settings.GoToSettingsScreen
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
@@ -21,6 +22,12 @@ interface DialogUiManager {
         activity: FragmentActivity,
         onBack: () -> Unit,
         onGoToSettings: () -> Unit,
+    )
+
+    fun displayBioOptOut(
+        activity: FragmentActivity,
+        onBack: () -> Unit,
+        onBiometricsOptIn: () -> Unit,
     )
 }
 
@@ -74,6 +81,29 @@ class BiometricsUiManager(
                     }
                 }
             }
+        activity.addContentView(
+            dialogView,
+            ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            ),
+        )
+    }
+
+    override fun displayBioOptOut(
+        activity: FragmentActivity,
+        onBack: () -> Unit,
+        onBiometricsOptIn: () -> Unit,
+    ) {
+        val dialogView = ComposeView(activity).apply {
+            setContent {
+                GdsTheme {
+                    BioOptOutScreen(onBack, onBiometricsOptIn) {
+                        (parent as? ViewGroup)?.removeView(this)
+                    }
+                }
+            }
+        }
         activity.addContentView(
             dialogView,
             ViewGroup.LayoutParams(

--- a/localauth/src/main/java/uk/gov/android/localauth/ui/BiometricsUiManager.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/ui/BiometricsUiManager.kt
@@ -98,7 +98,7 @@ class BiometricsUiManager(
         val dialogView = ComposeView(activity).apply {
             setContent {
                 GdsTheme {
-                    BioOptOutScreen(onBack, onBiometricsOptIn) {
+                    BioOptOutScreen(analyticsLogger, onBack, onBiometricsOptIn) {
                         (parent as? ViewGroup)?.removeView(this)
                     }
                 }

--- a/localauth/src/main/java/uk/gov/android/localauth/ui/optout/BioOptOutAnalyticsViewModel.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/ui/optout/BioOptOutAnalyticsViewModel.kt
@@ -1,0 +1,79 @@
+package uk.gov.android.localauth.ui.optout
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import uk.gov.android.authentication.localauth.R
+import uk.gov.logging.api.analytics.extensions.getEnglishString
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import uk.gov.logging.api.v3dot1.model.RequiredParameters
+import uk.gov.logging.api.v3dot1.model.TrackEvent
+import uk.gov.logging.api.v3dot1.model.ViewEvent
+
+class BioOptOutAnalyticsViewModel(
+    context: Context,
+    private val analyticsLogger: AnalyticsLogger,
+) : ViewModel() {
+
+    private val screenEvent = makeScreenEvent(context)
+    private val closeIconEvent = makeCloseBackEvent(context)
+    private val biometricsBtnEvent = makeButtonEvent(
+        context,
+        R.string.app_optOutBiometricsButton,
+    )
+    private val backBtnEvent = makeBackButtonEvent(context)
+
+    fun trackBioOptOutScreen() {
+        analyticsLogger.logEventV3Dot1(screenEvent)
+    }
+
+    fun trackBiometricsButton() {
+        analyticsLogger.logEventV3Dot1(biometricsBtnEvent)
+    }
+
+    fun trackCloseIconButton() {
+        analyticsLogger.logEventV3Dot1(closeIconEvent)
+    }
+
+    fun trackBackButton() {
+        analyticsLogger.logEventV3Dot1(backBtnEvent)
+    }
+
+    companion object {
+        internal fun makeScreenEvent(context: Context) = with(context) {
+            ViewEvent.Screen(
+                name = getEnglishString(R.string.app_optOutBiometricsTitle),
+                id = getEnglishString(R.string.bio_opt_out_screen_page_id),
+                params = requiredParams,
+            )
+        }
+
+        internal fun makeButtonEvent(context: Context, text: Int) = with(context) {
+            TrackEvent.Button(
+                text = getEnglishString(text),
+                params = requiredParams,
+            )
+        }
+
+        internal fun makeCloseBackEvent(context: Context) = with(context) {
+            TrackEvent.Icon(
+                text = getEnglishString(uk.gov.android.ui.componentsv2.R.string.close_button),
+                params = requiredParams,
+            )
+        }
+
+        internal fun makeBackButtonEvent(context: Context) = with(context) {
+            TrackEvent.Button(
+                text = getEnglishString(R.string.system_backButton),
+                params = requiredParams,
+            )
+        }
+
+        private val requiredParams = RequiredParameters(
+            taxonomyLevel2 = TaxonomyLevel2.WALLET,
+            taxonomyLevel3 = TaxonomyLevel3.BIOMETRICS,
+        )
+    }
+}

--- a/localauth/src/main/java/uk/gov/android/localauth/ui/optout/BioOptOutScreen.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/ui/optout/BioOptOutScreen.kt
@@ -3,6 +3,7 @@ package uk.gov.android.localauth.ui.optout
 import android.content.res.Configuration
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.collections.immutable.persistentListOf
@@ -15,21 +16,25 @@ import uk.gov.android.ui.patterns.errorscreen.ErrorScreen
 import uk.gov.android.ui.patterns.errorscreen.ErrorScreenIcon
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.android.ui.theme.meta.ScreenPreview
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BioOptOutScreen(
+    analyticsLogger: AnalyticsLogger,
     onBack: () -> Unit,
     onBiometricsOptIn: () -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val analyticsViewModel = BioOptOutAnalyticsViewModel(LocalContext.current, analyticsLogger)
+    analyticsViewModel.trackBioOptOutScreen()
     FullScreenDialogue(
         onDismissRequest = onDismiss,
         topAppBar = {
             FullScreenDialogueTopAppBar(
                 onCloseClick = {
                     onBack()
-
+                    analyticsViewModel.trackCloseIconButton()
                     onDismiss()
                 },
             ) {
@@ -38,17 +43,23 @@ fun BioOptOutScreen(
         },
         onBack = {
             onBack()
-
+            analyticsViewModel.trackBackButton()
             onDismiss()
         },
         content = {
-            BioOptOutContent(onBiometricsOptIn = onBiometricsOptIn)
+            BioOptOutContent(onBiometricsOptIn = {
+                onBiometricsOptIn()
+                analyticsViewModel.trackBiometricsButton()
+                onDismiss()
+            })
         },
     )
 }
 
 @Composable
-private fun BioOptOutContent(onBiometricsOptIn: () -> Unit) {
+private fun BioOptOutContent(
+    onBiometricsOptIn: () -> Unit,
+) {
     ErrorScreen(
         icon = ErrorScreenIcon.ErrorIcon,
         title = stringResource(R.string.app_optOutBiometricsTitle),

--- a/localauth/src/main/java/uk/gov/android/localauth/ui/optout/BioOptOutScreen.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/ui/optout/BioOptOutScreen.kt
@@ -1,0 +1,87 @@
+package uk.gov.android.localauth.ui.optout
+
+import android.content.res.Configuration
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import kotlinx.collections.immutable.persistentListOf
+import uk.gov.android.authentication.localauth.R
+import uk.gov.android.ui.patterns.centrealignedscreen.CentreAlignedScreenBodyContent
+import uk.gov.android.ui.patterns.centrealignedscreen.CentreAlignedScreenButton
+import uk.gov.android.ui.patterns.dialog.FullScreenDialogue
+import uk.gov.android.ui.patterns.dialog.FullScreenDialogueTopAppBar
+import uk.gov.android.ui.patterns.errorscreen.ErrorScreen
+import uk.gov.android.ui.patterns.errorscreen.ErrorScreenIcon
+import uk.gov.android.ui.theme.m3.GdsTheme
+import uk.gov.android.ui.theme.meta.ScreenPreview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BioOptOutScreen(
+    onBack: () -> Unit,
+    onBiometricsOptIn: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    FullScreenDialogue(
+        onDismissRequest = onDismiss,
+        topAppBar = {
+            FullScreenDialogueTopAppBar(
+                onCloseClick = {
+                    onBack()
+
+                    onDismiss()
+                },
+            ) {
+                // Nothing here (no title)
+            }
+        },
+        onBack = {
+            onBack()
+
+            onDismiss()
+        },
+        content = {
+            BioOptOutContent(onBiometricsOptIn = onBiometricsOptIn)
+        },
+    )
+}
+
+@Composable
+private fun BioOptOutContent(onBiometricsOptIn: () -> Unit) {
+    ErrorScreen(
+        icon = ErrorScreenIcon.ErrorIcon,
+        title = stringResource(R.string.app_optOutBiometricsTitle),
+        body = persistentListOf(
+            CentreAlignedScreenBodyContent.Text(stringResource(R.string.app_optOutBiometricsBody1)),
+            CentreAlignedScreenBodyContent.Text(stringResource(R.string.app_optOutBiometricsBody2)),
+            CentreAlignedScreenBodyContent.Text(stringResource(R.string.app_optOutBiometricsBody3)),
+        ),
+        primaryButton = CentreAlignedScreenButton(
+            text = stringResource(R.string.app_optOutBiometricsButton),
+            onClick = onBiometricsOptIn,
+            showIcon = false,
+        ),
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@ScreenPreview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+internal fun BioOptOutPreview() {
+    GdsTheme {
+        FullScreenDialogue(
+            onDismissRequest = {},
+            topAppBar = {
+                FullScreenDialogueTopAppBar({}) {
+                    // Nothing here
+                }
+            },
+            onBack = {},
+            content = {
+                BioOptOutContent(onBiometricsOptIn = {})
+            },
+        )
+    }
+}

--- a/localauth/src/main/res/values-cy/strings.xml
+++ b/localauth/src/main/res/values-cy/strings.xml
@@ -22,4 +22,10 @@
     <string name="app_wallet_enableBiometricsBullet2">gweld ac ychwanegu dogfennau</string>
     <!-- No Wallet Copy -->
     <string name="app_enableBiometricsBody1">Gallwch ddatgloi\'r ap gyda\'ch wyneb, olion bysedd neu iris o fewn 30 munud o fewngofnodi gyda GOV.UK One Login.</string>
+    <!-- Biometrics skipped screen -->
+    <string name="app_optOutBiometricsTitle">Mae angen i chi ddefnyddio biometreg</string>
+    <string name="app_optOutBiometricsBody1">I ychwanegu dogfennau, mae angen i chi ganiatáu i\'r ap hwn ddefnyddio eich wyneb, olion bysedd neu iris. Mae hyn er mwyn cadw\'ch dogfennau\'n ddiogel.</string>
+    <string name="app_optOutBiometricsBody2">Pan fyddwch yn defnyddio biometreg, bydd unrhyw un sy\'n gallu datgloi eich ffôn gyda\'u biometreg neu gyda phin neu batrwm eich ffôn yn gallu cael mynediad i\'ch ap.</string>
+    <string name="app_optOutBiometricsBody3">@string/app_enableBiometricsBody3</string>
+    <string name="app_optOutBiometricsButton">@string/app_enableBiometricsButton</string>
 </resources>

--- a/localauth/src/main/res/values/screen_ids.xml
+++ b/localauth/src/main/res/values/screen_ids.xml
@@ -3,4 +3,5 @@
     <string name="bio_opt_in_screen_wallet_page_id" translatable="false">4c6af885-a47f-4979-8b34-146574c73745</string>
     <string name="bio_opt_in_screen_no_wallet_page_id" translatable="false">33d0549e-dbe5-42ba-bae1-ada49d34e7a4</string>
     <string name="go_settings_screen_page_id" translatable="false">edc06a88-b779-4a17-9ed6-7a9c4103c290</string>
+    <string name="bio_opt_out_screen_page_id" translatable="false">6eef095c-3226-498b-a7ef-517c76ea0475</string>
 </resources>

--- a/localauth/src/main/res/values/strings.xml
+++ b/localauth/src/main/res/values/strings.xml
@@ -27,4 +27,11 @@
     <!-- Analytics default values -->
     <string name="system_backButton" translatable="false">back - system</string>
     <string name="icon_backButton" translatable="false">Back</string>
+
+    <!-- Biometrics skipped screen -->
+    <string name="app_optOutBiometricsTitle">You need to use biometrics</string>
+    <string name="app_optOutBiometricsBody1">To add documents, you need to allow this app to use your face, fingerprint or iris. This is to keep your documents secure.</string>
+    <string name="app_optOutBiometricsBody2">When you use biometrics, anyone who can unlock your phone with their biometrics or with your phone\'s pin or pattern might be able to access your app.</string>
+    <string name="app_optOutBiometricsBody3">app_enableBiometricsBody3</string>
+    <string name="app_optOutBiometricsButton">@string/app_enableBiometricsButton</string>
 </resources>

--- a/localauth/src/test/java/uk/gov/android/localauth/LocalAuthManagerTest.kt
+++ b/localauth/src/test/java/uk/gov/android/localauth/LocalAuthManagerTest.kt
@@ -145,7 +145,7 @@ class LocalAuthManagerTest : FragmentActivityTestCase(true) {
                 localAuthManager.enforceAndSet(
                     walletEnabled = false,
                     localAuthRequired = true,
-                    walletAddCredentialAttempt = true,
+                    enableOptOut = true,
                     activity = activity,
                     callbackHandler = callbackHandler,
                 )
@@ -175,7 +175,7 @@ class LocalAuthManagerTest : FragmentActivityTestCase(true) {
                 localAuthManager.enforceAndSet(
                     walletEnabled = false,
                     localAuthRequired = true,
-                    walletAddCredentialAttempt = true,
+                    enableOptOut = true,
                     activity = activity,
                     callbackHandler = callbackHandler,
                 )
@@ -210,7 +210,7 @@ class LocalAuthManagerTest : FragmentActivityTestCase(true) {
                 localAuthManager.enforceAndSet(
                     walletEnabled = false,
                     localAuthRequired = true,
-                    walletAddCredentialAttempt = true,
+                    enableOptOut = true,
                     activity = activity,
                     callbackHandler = callbackHandler,
                 )

--- a/localauth/src/test/java/uk/gov/android/localauth/LocalAuthManagerTest.kt
+++ b/localauth/src/test/java/uk/gov/android/localauth/LocalAuthManagerTest.kt
@@ -145,7 +145,6 @@ class LocalAuthManagerTest : FragmentActivityTestCase(true) {
                 localAuthManager.enforceAndSet(
                     walletEnabled = false,
                     localAuthRequired = true,
-                    enableOptOut = true,
                     activity = activity,
                     callbackHandler = callbackHandler,
                 )
@@ -175,7 +174,6 @@ class LocalAuthManagerTest : FragmentActivityTestCase(true) {
                 localAuthManager.enforceAndSet(
                     walletEnabled = false,
                     localAuthRequired = true,
-                    enableOptOut = true,
                     activity = activity,
                     callbackHandler = callbackHandler,
                 )
@@ -210,7 +208,6 @@ class LocalAuthManagerTest : FragmentActivityTestCase(true) {
                 localAuthManager.enforceAndSet(
                     walletEnabled = false,
                     localAuthRequired = true,
-                    enableOptOut = true,
                     activity = activity,
                     callbackHandler = callbackHandler,
                 )
@@ -382,9 +379,11 @@ class LocalAuthManagerTest : FragmentActivityTestCase(true) {
                 onNodeWithText(
                     context.getString(R.string.app_enablePasscodeOrPatternButton),
                 ).performClick()
+                onNodeWithText(
+                    context.getString(R.string.app_optOutBiometricsTitle),
+                ).assertIsDisplayed()
             }
 
-            verify(callbackHandler).onFailure(false)
             verify(localAuthPreferenceRepository)
                 .setLocalAuthPref(LocalAuthPreference.Disabled)
         }

--- a/localauth/src/test/java/uk/gov/android/localauth/ui/BiometricsUiManagerTest.kt
+++ b/localauth/src/test/java/uk/gov/android/localauth/ui/BiometricsUiManagerTest.kt
@@ -304,4 +304,105 @@ class BiometricsUiManagerTest : FragmentActivityTestCase(true) {
             assertTrue(onBack)
         }
     }
+
+    @Test
+    fun `test biometrics opt out screen`() {
+        composeTestRule.apply {
+            uiManager.displayBioOptOut(
+                activity,
+                onBack = {
+                    onBack = !onBack
+                },
+                onBiometricsOptIn = {
+                    onBioOptIn = !onBioOptIn
+                },
+            )
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsTitle),
+            ).assertIsDisplayed()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsBody1),
+            ).assertIsDisplayed()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsBody2),
+            ).assertIsDisplayed()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsBody3),
+            ).assertIsDisplayed()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsButton),
+            ).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `test primary button press on biometrics opt out screen`() {
+        onBioOptIn = false
+        composeTestRule.apply {
+            uiManager.displayBioOptOut(
+                activity,
+                onBack = {
+                    onBack = !onBack
+                },
+                onBiometricsOptIn = {
+                    onBioOptIn = !onBioOptIn
+                },
+            )
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsButton),
+            )
+                .assertIsDisplayed()
+                .performClick()
+
+            assertTrue(onBioOptIn)
+        }
+    }
+
+    @Test
+    fun `test hard back press on biometrics opt out screen`() {
+        onBack = false
+        composeTestRule.apply {
+            uiManager.displayBioOptOut(
+                activity,
+                onBack = {
+                    onBack = !onBack
+                },
+                onBiometricsOptIn = {
+                    onBioOptIn = !onBioOptIn
+                },
+            )
+
+            Espresso.pressBack()
+
+            assertTrue(onBack)
+        }
+    }
+
+    @Test
+    fun `test back button press on biometrics opt out screen`() {
+        onBack = false
+        composeTestRule.apply {
+            uiManager.displayBioOptOut(
+                activity,
+                onBack = {
+                    onBack = !onBack
+                },
+                onBiometricsOptIn = {
+                    onBioOptIn = !onBioOptIn
+                },
+            )
+
+            onNodeWithContentDescription(
+                context.getString(uk.gov.android.ui.componentsv2.R.string.close_button),
+            ).assertIsDisplayed().performClick()
+
+            assertTrue(onBack)
+        }
+    }
 }

--- a/localauth/src/test/java/uk/gov/android/localauth/ui/optout/BioOptOutAnalyticsViewModelTest.kt
+++ b/localauth/src/test/java/uk/gov/android/localauth/ui/optout/BioOptOutAnalyticsViewModelTest.kt
@@ -1,0 +1,92 @@
+package uk.gov.android.localauth.ui.optout
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import uk.gov.android.authentication.localauth.R
+import uk.gov.android.localauth.utils.TestUtils
+import uk.gov.logging.api.analytics.extensions.getEnglishString
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import uk.gov.logging.api.v3dot1.model.RequiredParameters
+import uk.gov.logging.api.v3dot1.model.ViewEvent
+
+@RunWith(AndroidJUnit4::class)
+class BioOptOutAnalyticsViewModelTest {
+    private lateinit var title: String
+    private lateinit var id: String
+    private lateinit var biometricsBtn: String
+    private lateinit var backBtn: String
+    private lateinit var requiredParameters: RequiredParameters
+    private lateinit var logger: AnalyticsLogger
+    private lateinit var viewModel: BioOptOutAnalyticsViewModel
+
+    @Before
+    fun setup() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        logger = mock()
+        requiredParameters = RequiredParameters(
+            taxonomyLevel2 = TaxonomyLevel2.WALLET,
+            taxonomyLevel3 = TaxonomyLevel3.BIOMETRICS,
+        )
+        title = context.getEnglishString(R.string.app_optOutBiometricsTitle)
+        id = context.getEnglishString(R.string.bio_opt_out_screen_page_id)
+        biometricsBtn = context.getEnglishString(R.string.app_optOutBiometricsButton)
+        backBtn = context.getEnglishString(R.string.system_backButton)
+        viewModel = BioOptOutAnalyticsViewModel(context, logger)
+    }
+
+    @Test
+    fun trackBioOptOutScreenEvent() {
+        val event = ViewEvent.Screen(
+            name = title,
+            id = id,
+            params = requiredParameters,
+        )
+        viewModel.trackBioOptOutScreen()
+
+        verify(logger).logEventV3Dot1(event)
+    }
+
+    @Test
+    fun trackButtons() {
+        listOf(
+            TestUtils.TrackEventTestCase.Button(
+                trackFunction = {
+                    viewModel.trackBiometricsButton()
+                },
+                text = biometricsBtn,
+            ),
+            TestUtils.TrackEventTestCase.Button(
+                trackFunction = {
+                    viewModel.trackBackButton()
+                },
+                text = backBtn,
+            ),
+        ).forEach {
+            val result = TestUtils.executeTrackEventTestCase(it, requiredParameters)
+
+            verify(logger).logEventV3Dot1(result)
+        }
+    }
+
+    @Test
+    fun trackBackButton() {
+        val event = ViewEvent.Screen(
+            name = title,
+            id = id,
+            params = requiredParameters,
+        )
+
+        viewModel.trackBioOptOutScreen()
+
+        verify(logger).logEventV3Dot1(event)
+    }
+}

--- a/localauth/src/test/java/uk/gov/android/localauth/ui/optout/BioOptOutScreenTest.kt
+++ b/localauth/src/test/java/uk/gov/android/localauth/ui/optout/BioOptOutScreenTest.kt
@@ -1,0 +1,137 @@
+package uk.gov.android.localauth.ui.optout
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import uk.gov.android.authentication.localauth.R
+import uk.gov.android.localauth.ui.optout.BioOptOutAnalyticsViewModel.Companion.makeBackButtonEvent
+import uk.gov.android.localauth.ui.optout.BioOptOutAnalyticsViewModel.Companion.makeButtonEvent
+import uk.gov.android.localauth.ui.optout.BioOptOutAnalyticsViewModel.Companion.makeCloseBackEvent
+import uk.gov.android.localauth.ui.optout.BioOptOutAnalyticsViewModel.Companion.makeScreenEvent
+import uk.gov.android.localauth.utils.FragmentActivityTestCase
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@RunWith(AndroidJUnit4::class)
+class BioOptOutScreenTest : FragmentActivityTestCase(false) {
+    private val analyticsLogger: AnalyticsLogger = mock()
+    private var onBack = false
+    private var onBioOptIn = false
+    private var onDismiss = 0
+
+    @Test
+    fun `test UI with wallet`() {
+        setupScreen()
+        composeTestRule.apply {
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsTitle),
+            ).assertIsDisplayed()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsBody1),
+            ).assertIsDisplayed()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsBody2),
+            ).assertIsDisplayed()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsBody3),
+            ).performScrollTo().assertExists()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsButton),
+            ).assertIsDisplayed()
+        }
+
+        verify(analyticsLogger).logEventV3Dot1(makeScreenEvent(context))
+    }
+
+    @Test
+    fun `test bio opt in button`() {
+        setupScreen()
+        val text = R.string.app_optOutBiometricsButton
+        composeTestRule.apply {
+            onNodeWithText(
+                context.getString(text),
+            ).performClick()
+
+            assertTrue(onBioOptIn)
+        }
+
+        verify(analyticsLogger).logEventV3Dot1(makeButtonEvent(context, text))
+    }
+
+    @Test
+    fun `test close button`() {
+        setupScreen()
+        composeTestRule.apply {
+            onNodeWithContentDescription(
+                context.getString(uk.gov.android.ui.componentsv2.R.string.close_button),
+            ).assertIsDisplayed().performClick()
+        }
+
+        assertEquals(1, onDismiss)
+        verify(analyticsLogger).logEventV3Dot1(makeCloseBackEvent(context))
+    }
+
+    @Test
+    fun `test back press`() {
+        setupScreen()
+        composeTestRule.apply {
+            Espresso.pressBack()
+
+            assertTrue(onBack)
+            verify(analyticsLogger).logEventV3Dot1(makeBackButtonEvent(context))
+        }
+    }
+
+    @Test
+    fun `test copy preview`() {
+        composeTestRule.apply {
+            setContent {
+                BioOptOutPreview()
+            }
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsTitle),
+            ).assertIsDisplayed()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsBody1),
+            ).assertIsDisplayed()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsBody2),
+            ).assertIsDisplayed()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsBody3),
+            ).performScrollTo().assertExists()
+
+            onNodeWithText(
+                context.getString(R.string.app_optOutBiometricsButton),
+            ).assertIsDisplayed()
+        }
+    }
+
+    private fun setupScreen() {
+        composeTestRule.setContent {
+            BioOptOutScreen(
+                analyticsLogger = analyticsLogger,
+                onBack = { onBack = !onBack },
+                onBiometricsOptIn = { onBioOptIn = !onBioOptIn },
+                onDismiss = { onDismiss++ },
+            )
+        }
+    }
+}


### PR DESCRIPTION
## DCMAW-13758: Error - User must use biometrics
## DCMAW-13764: Implement GA4 schema on the 'You need to use biometrics' screen

- Add biometrics opt out screen
- GA Analytics
- Add walletAddCredentialAttempt param to LocalAuthManager enforceAndSet function

### Evidence
| English | Welsh |
|--------|--------|
| ![localauth_day_en](https://github.com/user-attachments/assets/26a29a21-d5a0-4e6b-bc3e-07c5d3372de1) | ![localauth_optout_day_cy](https://github.com/user-attachments/assets/0747e37d-b967-49ae-a101-93a69a785688) |
| ![localauth_optout_night_end](https://github.com/user-attachments/assets/709722d7-130f-4194-a67e-ba263bc07284) | ![localauth_optout_dark_cy](https://github.com/user-attachments/assets/ece6c25b-d1d4-4a9a-861c-9ca0fa6b2755) | 