### PR TITLE
feat: Switch using ephemeral tabs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,7 +107,8 @@ dependencies {
         libs.kotlinx.serialization.json,
         libs.jose4j,
         libs.gson,
-        libs.bouncy.castle
+        libs.bouncy.castle,
+        libs.androidx.browser
     ).forEach(::implementation)
 
     listOf(

--- a/app/src/main/java/uk/gov/android/authentication/login/AppAuthSession.kt
+++ b/app/src/main/java/uk/gov/android/authentication/login/AppAuthSession.kt
@@ -3,6 +3,9 @@ package uk.gov.android.authentication.login
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.OptIn
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.ExperimentalEphemeralBrowsing
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
@@ -14,11 +17,16 @@ class AppAuthSession(
     private val authService: AuthorizationService = AuthorizationService(context)
     private val clientAuthenticationProvider = ClientAuthenticationProviderImpl()
 
+    @OptIn(ExperimentalEphemeralBrowsing::class)
     override fun present(
         launcher: ActivityResultLauncher<Intent>,
         configuration: LoginSessionConfiguration
     ) {
-        val intent = authService.getAuthorizationRequestIntent(configuration.createRequest())
+        val customEphemeralTabIntent = CustomTabsIntent.Builder()
+            .setEphemeralBrowsingEnabled(true)
+            .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+            .build()
+        val intent = authService.getAuthorizationRequestIntent(configuration.createRequest(), customEphemeralTabIntent)
         launcher.launch(intent)
     }
 

--- a/app/src/main/java/uk/gov/android/authentication/login/AppAuthSession.kt
+++ b/app/src/main/java/uk/gov/android/authentication/login/AppAuthSession.kt
@@ -26,7 +26,10 @@ class AppAuthSession(
             .setEphemeralBrowsingEnabled(true)
             .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
             .build()
-        val intent = authService.getAuthorizationRequestIntent(configuration.createRequest(), customEphemeralTabIntent)
+        val intent = authService.getAuthorizationRequestIntent(
+            configuration.createRequest(),
+            customEphemeralTabIntent
+        )
         launcher.launch(intent)
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "a
 appauth = { group = "net.openid", name = "appauth", version = "0.11.1" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+androidx-browser = { group = "androidx.browser", name = "browser", version = "1.9.0-alpha01"}
 
 # Local Auth
 androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "androidxBiometric" }


### PR DESCRIPTION
- switch from using default CustomTab to ephemeral one for login to avoid sharing/ storing cookies in default browsers as this can create issues for cross-browser users

**This implementation does not work for Samsung Browser AND Firefox**

Resolves: DCMAW-14232