### PR TITLE
feat: mobile ui repo version bump

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ androidxBiometric = "1.1.0"
 androidx-ui = "1.8.2"
 material3 = "1.3.2"
 ktlint-cli = "0.49.1"
-govuk-ui = "7.31.1"
+govuk-ui = "7.40.0"
 govuk-logging = "0.25.0"
 paparazzi = "1.3.5"
 

--- a/localauth/src/main/java/uk/gov/android/localauth/ui/optin/BioOptInScreen.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/ui/optin/BioOptInScreen.kt
@@ -62,7 +62,6 @@ fun BioOptInScreen(
         analyticsViewModel.trackBioOptInNoWalletScreen()
     }
     FullScreenDialogue(
-        onDismissRequest = onDismiss,
         topAppBar = {
             FullScreenDialogueTopAppBar(
                 modifier = Modifier.semantics(true) {
@@ -226,7 +225,6 @@ private fun CustomText(text: String, accessibilityIndex: Float) {
 internal fun BioOptInPreviewWallet() {
     GdsTheme {
         FullScreenDialogue(
-            onDismissRequest = {},
             topAppBar = {
                 FullScreenDialogueTopAppBar({}) {
                     // Nothing here
@@ -247,7 +245,6 @@ internal fun BioOptInPreviewWallet() {
 internal fun BioOptInPreview() {
     GdsTheme {
         FullScreenDialogue(
-            onDismissRequest = {},
             topAppBar = {
                 FullScreenDialogueTopAppBar({}) {
                     // Nothing here

--- a/localauth/src/main/java/uk/gov/android/localauth/ui/optout/BioOptOutScreen.kt
+++ b/localauth/src/main/java/uk/gov/android/localauth/ui/optout/BioOptOutScreen.kt
@@ -29,7 +29,6 @@ fun BioOptOutScreen(
     val analyticsViewModel = BioOptOutAnalyticsViewModel(LocalContext.current, analyticsLogger)
     analyticsViewModel.trackBioOptOutScreen()
     FullScreenDialogue(
-        onDismissRequest = onDismiss,
         topAppBar = {
             FullScreenDialogueTopAppBar(
                 onCloseClick = {
@@ -83,7 +82,6 @@ private fun BioOptOutContent(
 internal fun BioOptOutPreview() {
     GdsTheme {
         FullScreenDialogue(
-            onDismissRequest = {},
             topAppBar = {
                 FullScreenDialogueTopAppBar({}) {
                     // Nothing here


### PR DESCRIPTION
- Replace deprecated uses of FullScreenDialogue

Resolves: DCMAW-14007

### Evidence

| Before | After |
|--------|--------|
| <img width="1008" height="2244" alt="bio_opt_in_pre_change" src="https://github.com/user-attachments/assets/715d1be5-34fa-4b63-9e51-b73833c9c5bc" /> | <img width="1008" height="2244" alt="bio_opt_in_post_change" src="https://github.com/user-attachments/assets/d968509e-46f6-4a3a-be2d-f18566edfdff" /> |
| <img width="1008" height="2244" alt="bio_opt_out_pre_change" src="https://github.com/user-attachments/assets/50a984b3-3275-42c4-8439-02e62b071157" /> | <img width="1008" height="2244" alt="bio_opt_out_post_change" src="https://github.com/user-attachments/assets/de11a28b-cd87-4ba6-bb2e-bcbe564b5972" /> | 