### PR TITLE
feat!: Add logger to `FirebaseAppIntegrityManager` constructor

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,7 +108,8 @@ dependencies {
         libs.jose4j,
         libs.gson,
         libs.bouncy.castle,
-        libs.androidx.browser
+        libs.androidx.browser,
+        libs.logging
     ).forEach(::implementation)
 
     listOf(
@@ -116,7 +117,8 @@ dependencies {
         kotlin("test-junit5"),
         libs.bundles.test,
         platform(libs.junit.bom),
-        libs.mockito.kotlin
+        libs.mockito.kotlin,
+        libs.mockito.inline
     ).forEach(::testImplementation)
 
     listOf(

--- a/app/src/main/java/uk/gov/android/authentication/integrity/pop/ProofOfPossessionGenerator.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/pop/ProofOfPossessionGenerator.kt
@@ -1,7 +1,7 @@
 package uk.gov.android.authentication.integrity.pop
 
+import java.time.Instant
 import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlinx.serialization.Serializable
@@ -12,7 +12,7 @@ object ProofOfPossessionGenerator {
     fun createBase64PoP(
         iss: String,
         aud: String,
-        exp: Long = getExpiryTime(),
+        exp: Long,
         jti: String = Uuid.random().toString()
     ): String {
         val pop = ProofOfPossession(
@@ -57,15 +57,19 @@ object ProofOfPossessionGenerator {
         val jti: String
     )
 
-    private fun getExpiryTime(): Long {
+    fun getExpiryTime(): Long {
         val minuteUntilExpiry = (MINUTES * MINUTE_IN_MILLISECONDS)
-        return (System.currentTimeMillis() + minuteUntilExpiry) / CONVERT_TO_SECONDS
+        val expiry = (Instant.now().toEpochMilli() + minuteUntilExpiry) / CONVERT_TO_SECONDS
+        return expiry
     }
 
-    @OptIn(ExperimentalEncodingApi::class)
     fun getUrlSafeNoPaddingBase64(input: ByteArray): String {
         return Base64.UrlSafe.withPadding(Base64.PaddingOption.ABSENT)
             .encode(input)
+    }
+
+    fun isPopExpired(exp: Long): Boolean {
+        return exp <= (Instant.now().toEpochMilli() / CONVERT_TO_SECONDS)
     }
 
     private const val ALG = "ES256"

--- a/app/src/test/java/uk/gov/android/authentication/integrity/pop/ProofOfPossessionGeneratorTest.kt
+++ b/app/src/test/java/uk/gov/android/authentication/integrity/pop/ProofOfPossessionGeneratorTest.kt
@@ -1,7 +1,10 @@
 package uk.gov.android.authentication.integrity.pop
 
+import java.time.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ProofOfPossessionGeneratorTest {
     @Test
@@ -15,5 +18,27 @@ class ProofOfPossessionGeneratorTest {
         )
 
         assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `test if PoP is expired - true`() {
+        val expiredDateInSeconds =
+            (Instant.now().toEpochMilli() - (MINUTES * MINUTE_IN_MILLISECONDS)) / CONVERT_TO_SECONDS
+
+        assertTrue(ProofOfPossessionGenerator.isPopExpired(expiredDateInSeconds))
+    }
+
+    @Test
+    fun `test if PoP is expired - false`() {
+        val validDateInSeconds =
+            (Instant.now().toEpochMilli() + (MINUTES * MINUTE_IN_MILLISECONDS)) / CONVERT_TO_SECONDS
+
+        assertFalse(ProofOfPossessionGenerator.isPopExpired(validDateInSeconds))
+    }
+
+    companion object {
+        private const val MINUTES = 3
+        private const val MINUTE_IN_MILLISECONDS = 60000
+        private const val CONVERT_TO_SECONDS = 1000
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,6 +95,7 @@ android-test-core-ktx = { group = "androidx.test", name = "core-ktx", version.re
 android-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "test-ext-junit" }
 mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockito-kotlin" }
 mockito-android = { group = "org.mockito", name = "mockito-android", version.ref = "mockito-android" }
+mockito-inline = { group = "org.mockito", name = "mockito-inline", version = "5.2.0" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 espresso-intents = { group = "androidx.test.espresso", name = "espresso-intents", version.ref = "espresso-core" }
 androidx-test-orchestrator = { group = "androidx.test", name = "orchestrator", version.ref = "test-orchestrator" }


### PR DESCRIPTION
- log error if the PoP is expired after signing the JWT or info if not expired
- change init expiryTime for PoP to inside `generatePoP(...)`

Resolves: DCMAW-14540