### PR TITLE
fix: Style change to force new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dependencyResolutionManagement {
 ```
 
 2. For local development, ensure you have a `github.properties` in the project's root which includes your username and an access token. **Do not commit this file to Version Control**
-3. Add `implementation("uk.gov.android:authentication:_")` for latest version. Check packages for version information
+3. Add `implementation("uk.gov.android:authentication:_")` for latest version and check packages for version information
 
 ## Package description
 


### PR DESCRIPTION
- new version is needed to be consumed by the app in order to avoid a crash - the actual version bump used a commit that is not recognised as a bump version one