### PR TITLE
chore: Address security warning about exposed JWT Tokens

### DIFF
--- a/app/src/androidTest/java/uk/gov/android/authentication/integrity/keymanager/ECKeyManagerTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/authentication/integrity/keymanager/ECKeyManagerTest.kt
@@ -17,10 +17,11 @@ class ECKeyManagerTest {
     private lateinit var ecKeyManager: ECKeyManager
     private val jwtVerifier = Jose4jJwtVerifier()
 
+    // Unsigned jwt generated from dummy values
     private val manuallyGeneratedTestJwtHeaderAndBody =
-        "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJiWXJjdUFiY2RFZmdqZEVnWVNTYkJqd1h6SHJ3SiIsImF1ZCI6Imh" +
-            "0dHBzOi8vZXhhbXBsZS5jb20iLCJleHAiOjE3MzMyNjE2MjYsImp0aSI6ImE3ZmNhMzRlLWJlNzI" +
-            "tNDJmYi05MDY1LTRkNTVlOWMxNjljZSJ9"
+        "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJiWXJjdUFiY2RFZmdqZEVnWVNTYkJqd1h6SHJ3SiIsImF1ZCI6Imh0d" +
+            "HBzOi8vZXhhbXBsZS5jb20iLCJleHAiOjE3MzMyNjE2MjYsImp0aSI6IjQ2NjkxZjBjLTVmYzktND" +
+            "lmOS1hNjg0LWU4Y2YwZWE1YjJkZiJ9"
 
     @BeforeTest
     fun setup() {

--- a/app/src/main/java/uk/gov/android/authentication/integrity/pop/ProofOfPossessionGenerator.kt
+++ b/app/src/main/java/uk/gov/android/authentication/integrity/pop/ProofOfPossessionGenerator.kt
@@ -25,11 +25,6 @@ import uk.gov.android.authentication.json.jwk.JWK
  * All generated tokens follow the JWT structure (header.payload) but are **unsigned**.
  * The tokens are Base64URL-encoded without padding, as per RFC 7515.
  *
- * Example output format:
- * ```
- * eyJhbGciOiJFUzI1NiIsInR5cCI6Im9hdXRoLWNsaWVudC1hdHRlc3RhdGlvbi1wb3Arand0In0.eyJpc3MiOiJ1cm46ZmRjOmdvdjp1azp3YWxsZXQiLCJhdWQiOiJodHRwczovL3Rva2VuLmFjY291bnQuZ292LnVrIiwiZXhwIjoxNzM0NTY3ODkwLCJqdGkiOiJkM2U4ZTM4Mi00NjkxLTRiMWYtODNjMS00NDU0Zjc1YmQ5MzAifQ
- * ```
- *
  * ## Security Considerations
  *
  * - Tokens are **not signed** by this generator; signing must be performed separately


### PR DESCRIPTION
# [DCMAW-18772](https://govukverify.atlassian.net/browse/DCMAW-18772): Pen Test (ITHC) Outcomes | Exposed JWT Tokens Detected

- Remove example jwt and replace a test jwt with one using dummy values



[DCMAW-18772]: https://govukverify.atlassian.net/browse/DCMAW-18772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ