### PR TITLE
ci: Update PR workflow triggers

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -2,13 +2,10 @@ name: On Pull Request
 
 on:
   pull_request:
-    branches:
-      - main
     types:
       - opened
       - reopened
       - synchronize
-      - ready_for_review
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
## Changes

- Remove base branch restriction for PR checks
- Remove `ready_for_review` trigger for PR checks

## Context

Brings the PR check triggers in line with other Android projects in One Login.

- Enables checks to run for stacked PRs
- Prevents time wasted when checks re-run after changing a draft PR to ready for review